### PR TITLE
Link to correct version of CoreUI in config

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -127,7 +127,7 @@ return [
         // 'https://code.jquery.com/jquery-3.4.1.min.js',
         // 'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js',
         // 'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js',
-        // 'https://unpkg.com/@coreui/coreui/dist/js/coreui.min.js',
+        // 'https://unpkg.com/@coreui/coreui@2.1.16/dist/js/coreui.min.js',
         // 'https://cdnjs.cloudflare.com/ajax/libs/pace/1.0.2/pace.min.js',
         // 'https://unpkg.com/sweetalert/dist/sweetalert.min.js',
         // 'https://cdnjs.cloudflare.com/ajax/libs/noty/3.1.4/noty.min.js'


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?



It appears that provided CoreUI CDN link (https://unpkg.com/@coreui/coreui/dist/js/coreui.min.js) now points to the most recent version, v4.1.6, but bundle.js includes older CoreUI v2.1.16.

### AFTER - What is happening after this PR?

If I replace CoreUI CDN link with the correct version link - https://unpkg.com/@coreui/coreui@2.1.16/dist/js/coreui.min.js it works as expected.

## HOW

### How did you achieve that, in technical terms?

I used CDN link to the same version that is used to build bundle.js



### Is it a breaking change?

Not this isn't a breaking change

### How can we test the before & after?

Comment line with bundle.js and uncomment CDN lines. Before - the sidebar doesn't collapse, after - it works just like when using bundle.js
